### PR TITLE
Support the use case with TestCaseSource attribute

### DIFF
--- a/src/TestRailClient.V2.NUnit/NUnitTestRailClient.cs
+++ b/src/TestRailClient.V2.NUnit/NUnitTestRailClient.cs
@@ -145,7 +145,7 @@ namespace Ycode.TestRailClient.V2.NUnit
             	elapsed: stopwatch?.Elapsed);
         }
 
-    	public async Task<List<TestRailResult>> RecordResultAsync(TestContext context, string version = null, string comment = null, TimeSpan? elapsed = null)
+    	protected async Task<List<TestRailResult>> RecordResultAsync(TestContext context, string version = null, string comment = null, TimeSpan? elapsed = null)
         {
         	var (caseIds, defects) = ReadAttributesOnTest(context);
 

--- a/src/TestRailClient.V2.NUnit/TestContextExtensions.cs
+++ b/src/TestRailClient.V2.NUnit/TestContextExtensions.cs
@@ -1,0 +1,10 @@
+﻿using NUnit.Framework;
+
+namespace Ycode.TestRailClient.V2.NUnit
+{
+    public static class TestContextExtensions
+    {
+        public static TestCaseData AddTestRailCase(this TestCaseData data, int caseId)
+            => data.SetProperty(TestRailCaseAttribute.Name, caseId);
+    }
+}

--- a/test/TestRailClient.Test.ApiMock/Controllers/CaseV2Controller.cs
+++ b/test/TestRailClient.Test.ApiMock/Controllers/CaseV2Controller.cs
@@ -154,6 +154,39 @@ namespace Ycode.TestRailClient.Test.ApiMock.Controllers
                             TypeId = 1,
                             Refs = null,
                         },
+                        new CaseV2
+                        {
+                            Id = 10112,
+                            SuiteId = 100,
+                            SectionId = 5,
+                            TemplateId = 1,
+                            Title = "Test 12",
+                            PriorityId = 5,
+                            TypeId = 1,
+                            Refs = null,
+                        },
+                        new CaseV2
+                        {
+                            Id = 10113,
+                            SuiteId = 100,
+                            SectionId = 5,
+                            TemplateId = 1,
+                            Title = "Test 13",
+                            PriorityId = 5,
+                            TypeId = 1,
+                            Refs = null,
+                        },
+                        new CaseV2
+                        {
+                            Id = 10114,
+                            SuiteId = 100,
+                            SectionId = 5,
+                            TemplateId = 1,
+                            Title = "Test 14",
+                            PriorityId = 5,
+                            TypeId = 1,
+                            Refs = null,
+                        },
                     },
                     200 => new[]
                     {

--- a/test/samples/Sample1/SampleTests.cs
+++ b/test/samples/Sample1/SampleTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NUnit.Framework;
 using Ycode.TestRailClient.V2;
 using Ycode.TestRailClient.V2.NUnit;
@@ -55,6 +56,27 @@ namespace Sample1
         public void Test5(int param1, string param2)
         {
             Assert.Fail();
+        }
+
+        [TestCaseSource(typeof(TestCaseSource), "TestCases")]
+        public int Test6(int n, int d)
+        {
+            return n / d;
+        }
+
+        public class TestCaseSource
+        {
+            public static IEnumerable<TestCaseData> TestCases
+            {
+                get
+                {
+                    yield return new TestCaseData(12, 3).Returns(4) // to pass
+                        .AddTestRailCase(10112);
+                    yield return new TestCaseData(12, 2).Returns(5) // to fail
+                        .AddTestRailCase(10113)
+                        .AddTestRailCase(10114);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
I think that only supporting the usage with TestCaseData array would make it simple among a variety of use cases with TestCaseSource attribute.

Therefore, this solution simply provides an extension method against TestCaseData class so as to allow adding TestRail case ID's.